### PR TITLE
Fix for go.mod module definition, closes #6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/ahmedaabouzied/blockscore-go
+module github.com/connorjacobsen/blockscore-go
 
 go 1.12


### PR DESCRIPTION
Until this gets merged, you can clone my fixed fork into your vendors and do something like:
```
replace github.com/connorjacobsen/blockscore-go => ./vendor/github.com/connorjacobsen/blockscore-go
```