### PR TITLE
fix: point go.mod to the repository the code is hosted under

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/ahmedaabouzied/blockscore-go
+module github.com/connorjacobsen/blockscore-go
 
-go 1.12
+go 1.20


### PR DESCRIPTION
Point go.mod to the same Github repository the code is hosted under.

The [ahmedaabouzied](https://github.com/ahmedaabouzied) fork no longer exists.

Also, update to the latest release Go version.